### PR TITLE
Update test matrix to exclude specific configurations

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -16,6 +16,13 @@ jobs:
         julia-version: ['1', 'nightly']
         julia-arch: [x64, x86]
         os: [ubuntu-latest, windows-latest]
+        exclude:
+          - os: ubuntu-latest
+            julia-version: 'nightly'
+            julia-arch: x64
+          - os: ubuntu-latest
+            julia-version: 'nightly'
+            julia-arch: x86
         include:
             - os: macOS-latest
               julia-version: 'nightly'


### PR DESCRIPTION
Exclude nightly Julia version tests on Ubuntu for both architectures.